### PR TITLE
Fix Dockerfile: Update Ubuntu version and correct ownership

### DIFF
--- a/challenge/Dockerfile
+++ b/challenge/Dockerfile
@@ -1,7 +1,7 @@
 # sudo docker build -t system_health_check .
 # sudo docker run -d -p 1024:1024 --rm -it system_health_check
 
-FROM ubuntu:19.10
+FROM ubuntu:22.04
 
 RUN apt-get update
 

--- a/challenge/Dockerfile
+++ b/challenge/Dockerfile
@@ -14,7 +14,7 @@ COPY system_health_check .
 COPY flag .
 COPY ynetd .
 
-RUN chown -R root:root /home/ctf
+RUN chown -R ctf:ctf /home/ctf
 
 USER ctf
 EXPOSE 1024


### PR DESCRIPTION
This pull request addresses two issues in the Dockerfile located in `pwn_docker_example/challenge/Dockerfile`:

1. **Updated Ubuntu Version:** The base image was changed from `ubuntu:19.10` (which is EOL) to `ubuntu:22.04`, ensuring compatibility and support.
2. **Corrected File Ownership:** The ownership of `/home/ctf` is updated to the correct user `ctf` to resolve permission issues when running the container.

These changes improve the Dockerfile's functionality and ensure the container works as intended.